### PR TITLE
Refactor ApplicationEventPublisher

### DIFF
--- a/packages/core/src/application/abstract-application.spec.ts
+++ b/packages/core/src/application/abstract-application.spec.ts
@@ -163,7 +163,7 @@ describe("Application", () => {
 
     it("binds event publishing context", async () => {
         const eventSubscriber = vi.fn();
-        eventPublisher.onPublish(eventSubscriber);
+        eventPublisher.subscribe(eventSubscriber);
         const trigger = {
             type: "trigger-message",
         };

--- a/packages/core/src/application/application-event-publisher.spec.ts
+++ b/packages/core/src/application/application-event-publisher.spec.ts
@@ -13,7 +13,7 @@ describe("application event publisher", () => {
     });
 
     test("subscribing", async () => {
-        publisher.onPublish(subscriber);
+        publisher.subscribe(subscriber);
 
         await publisher.publish({
             type: "test-1",
@@ -29,8 +29,8 @@ describe("application event publisher", () => {
     });
 
     test("subscribing twice", async () => {
-        publisher.onPublish(subscriber);
-        publisher.onPublish(subscriber);
+        publisher.subscribe(subscriber);
+        publisher.subscribe(subscriber);
 
         await publisher.publish({
             type: "test-1",
@@ -44,7 +44,7 @@ describe("application event publisher", () => {
     }
 
     test("callbacks run event by event", async () => {
-        publisher.onPublish(() => wait(50));
+        publisher.subscribe(() => wait(50));
 
         const tStart = Date.now();
         await publisher.publish({
@@ -59,7 +59,7 @@ describe("application event publisher", () => {
     });
 
     test("context", async () => {
-        publisher.onPublish(subscriber);
+        publisher.subscribe(subscriber);
 
         await publisher.bindContext({ foo: "bar" }, async () => {
             await publisher.publish({
@@ -74,7 +74,7 @@ describe("application event publisher", () => {
     });
 
     test("publishing fails when subscriber throws", async () => {
-        publisher.onPublish(() => {
+        publisher.subscribe(() => {
             throw new Error("test");
         });
 
@@ -88,8 +88,8 @@ describe("application event publisher", () => {
     test("unsubscribing", async () => {
         const subscriber2 = vi.fn();
 
-        const unsubscribe = publisher.onPublish(subscriber);
-        publisher.onPublish(subscriber2);
+        const unsubscribe = publisher.subscribe(subscriber);
+        publisher.subscribe(subscriber2);
 
         await publisher.publish({
             type: "test-1",
@@ -106,7 +106,7 @@ describe("application event publisher", () => {
     });
 
     test("publishing multiple events", async () => {
-        publisher.onPublish(subscriber);
+        publisher.subscribe(subscriber);
 
         await publisher.publish({ id: 1 }, { id: 2 });
 

--- a/packages/core/src/application/application-event-publisher.ts
+++ b/packages/core/src/application/application-event-publisher.ts
@@ -18,12 +18,9 @@ export class ApplicationEventPublisher<
         return await this.contextStorage.run(context, callback);
     }
 
-    public onPublish(callback: PublishCallback<E, C>): () => void {
-        const unsubscribe = () => this.unsubscribe(callback);
-
+    public subscribe(callback: PublishCallback<E, C>): () => void {
         this.callbacks.add(callback);
-
-        return unsubscribe;
+        return () => this.unsubscribe(callback);
     }
 
     private unsubscribe(callback: PublishCallback<E, C>): void {

--- a/packages/core/src/application/application-event-publisher.ts
+++ b/packages/core/src/application/application-event-publisher.ts
@@ -11,7 +11,7 @@ export class ApplicationEventPublisher<
     C extends object = any,
 > implements EventPublisher<E>
 {
-    private callbacks: Array<PublishCallback<E, C>> = [];
+    private callbacks: Set<PublishCallback<E, C>> = new Set();
     private contextStorage = new AsyncLocalStorage<C>();
 
     async bindContext<R>(context: C, callback: () => Promise<R>): Promise<R> {
@@ -21,20 +21,13 @@ export class ApplicationEventPublisher<
     public onPublish(callback: PublishCallback<E, C>): () => void {
         const unsubscribe = () => this.unsubscribe(callback);
 
-        if (!this.callbacks.includes(callback)) {
-            this.callbacks.push(callback);
-        }
+        this.callbacks.add(callback);
 
         return unsubscribe;
     }
 
     private unsubscribe(callback: PublishCallback<E, C>): void {
-        const index = this.callbacks.indexOf(callback);
-        if (index === -1) {
-            return;
-        }
-
-        this.callbacks.splice(index, 1);
+        this.callbacks.delete(callback);
     }
 
     public async publish(...events: E[]): Promise<void> {


### PR DESCRIPTION
- by replacing callbacks type with `Set`
- Rename `onPublish` method for ease of usage