### PR TITLE
fix(cli, plugin-application-builder): widen typescript peer to allow TypeScript 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,6 @@ dist
 todo.txt
 todo
 
-# claude files
+# claude / codex files
 .claude
+.codex

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.3] - 2026-06-19
+
+### Changed
+
+- Peer dependency: `typescript` `^5.0.0` → `^5.0.0 || ^6.0.0` (allow TypeScript 6 consumers)
+
 ## [0.2.2] - 2026-03-07
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Unified CLI tool for hexai plugins",
   "license": "MIT",
@@ -52,7 +52,7 @@
     "commander": "^12.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@hexaijs/tooling": "workspace:*",

--- a/packages/plugin-application-builder/CHANGELOG.md
+++ b/packages/plugin-application-builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.5] - 2026-06-19
+
+### Changed
+
+- Peer dependency: `typescript` `^5.0.0` → `^5.0.0 || ^6.0.0` (allow TypeScript 6 consumers)
+
 ## [0.2.4] - 2026-03-07
 
 ### Changed

--- a/packages/plugin-application-builder/package.json
+++ b/packages/plugin-application-builder/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "Build plugin for generating ApplicationBuilder code from decorated handlers",
   "license": "MIT",
@@ -60,7 +60,7 @@
     "@hexaijs/core": "^0.9.0",
     "@hexaijs/application": "^0.5.0",
     "@hexaijs/cli": "^0.2.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@hexaijs/application": "workspace:^",


### PR DESCRIPTION
## What

- `@hexaijs/cli`: peer `typescript` `^5.0.0` → `^5.0.0 || ^6.0.0`, version `0.2.2` → `0.2.3`
- `@hexaijs/plugin-application-builder`: same widening, version `0.2.4` → `0.2.5`
- `chore`: gitignore `.codex` local tool dir

## Why

`@hexaijs/cli`'s narrow `^5.0.0` typescript peer blocked TypeScript 6 consumers (found during a downstream migration). `plugin-application-builder` had the identical too-narrow peer. Both now match `plugin-contracts-generator`'s already-widened `^5.0.0 || ^6.0.0`.

Codegen across both generators is **AST-only** (no `createProgram`/`getTypeChecker`), so the TS6 surface change does not affect it — widening is low-risk.

## Validation

- JSON valid, peer values confirmed (`^5.0.0 || ^6.0.0`)
- CHANGELOG entries added per package (Keep a Changelog format)